### PR TITLE
increase size of allowed request body from 100kb to 500kb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y epel-release && \
     yum install -y npm nodejs && \
     yum clean all
 
-RUN yum install -y https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox-0.12.5-1.centos7.x86_64.rpm
+RUN yum install -y https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos7.x86_64.rpm
 
 ADD app app
 

--- a/app/app.js
+++ b/app/app.js
@@ -4,7 +4,7 @@ var wkhtmltopdf = require('wkhtmltopdf');
 
 var app = express();
 
-app.use(bodyParser.json( { limit: '500kb' }));
+app.use(bodyParser.json( { limit: '10mb' }));
 
 app.post('/', (req, res) => {
   res.setHeader('content-type', 'application/pdf');

--- a/app/app.js
+++ b/app/app.js
@@ -4,7 +4,7 @@ var wkhtmltopdf = require('wkhtmltopdf');
 
 var app = express();
 
-app.use(bodyParser.json());
+app.use(bodyParser.json( { limit: '500kb' }));
 
 app.post('/', (req, res) => {
   res.setHeader('content-type', 'application/pdf');

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-pdf",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple microservice which allows you to convert HTML to a PDF file. With wkhtmltopdf.",
   "main": "app.js",
   "author": "Marcel Gross <marcel.gross@kurzdigital.com>",


### PR DESCRIPTION
Was trying to use this package to generate a larger PDF (about 20 styled pages, ~200kb) and failed on request for content being too large. Increased the size to cover larger requests.